### PR TITLE
Connection

### DIFF
--- a/daos/daos_impl/batch_dao_impl.py
+++ b/daos/daos_impl/batch_dao_impl.py
@@ -2,21 +2,21 @@ import psycopg2
 from daos.batch_dao import BatchDAO
 from exceptions.resource_not_found import ResourceNotFound
 from models.batch import Batch
-from utils.connection import Connection
-
-conn = Connection.conn
 
 
 class BatchDAOImpl(BatchDAO):
+
     @staticmethod
     def create_batch(cursor, batch: Batch) -> Batch:
         if type(batch.start_date) != int or type(batch.end_date) != int:
             raise psycopg2.errors.InvalidDatetimeFormat(
-                f"{batch.start_date} and {batch.end_date} are in invalid format.")
+                f"{batch.start_date} and {batch.end_date} are in invalid format."
+            )
         elif batch.start_date < batch.end_date:
             sql = """insert into batches values(default, %s, %s, %s, %s)  returning id;"""
             cursor.execute(sql, [
-                batch.start_date, batch.end_date, batch.name, batch.training_track
+                batch.start_date, batch.end_date, batch.name,
+                batch.training_track
             ])
             batch.id = cursor.fetchone()[0]
             return batch

--- a/daos/daos_impl/note_dao_impl.py
+++ b/daos/daos_impl/note_dao_impl.py
@@ -4,19 +4,18 @@ from psycopg2 import errors
 from daos.note_dao import NoteDao
 from exceptions.resource_not_found import ResourceNotFound
 from models.note import Note
-from utils.connection import Connection
-
-conn = Connection.conn
 
 
 class NoteDAOImpl(NoteDao):
+
     def add_note(self, cursor, note: Note) -> Note:
         if note.week_number < 0:
             raise ValueError()
         try:
             """Creates a note for an Associate on a given week for a Batch"""
             sql = "insert into notes (batch_id, cont, associate_id, week_number) values(%s, %s, %s, %s) returning id"
-            cursor.execute(sql, (note.batch_id, note.content, note.associate_id, note.week_number))
+            cursor.execute(sql, (note.batch_id, note.content, note.associate_id,
+                                 note.week_number))
             conn.commit()
             n_id = cursor.fetchone()[0]
             note.note_id = n_id
@@ -24,7 +23,6 @@ class NoteDAOImpl(NoteDao):
         except psycopg2.Error as e:
             if int(e.pgcode) == 23503 or int(e.pgcode) == 42830:
                 raise ResourceNotFound("The foreign keys provided do not exist")
-
 
     def get_single_note(self, cursor, note_id: int) -> Note:
         """Takes in an id for a note record and returns a Note object"""
@@ -49,11 +47,12 @@ class NoteDAOImpl(NoteDao):
         records = cursor.fetchall()
         notes = []
         for note in records:
-            notes.append(Note(note_id=note[0],
-                              batch_id=note[1],
-                              content=note[2],
-                              associate_id=note[3],
-                              week_number=note[4]))
+            notes.append(
+                Note(note_id=note[0],
+                     batch_id=note[1],
+                     content=note[2],
+                     associate_id=note[3],
+                     week_number=note[4]))
         return notes
 
     def update_note(self, cursor, updated: Note) -> Note:
@@ -62,7 +61,9 @@ class NoteDAOImpl(NoteDao):
             raise ValueError()
         try:
             sql = "update notes set batch_id = %s, cont = %s, associate_id = %s, week_number = %s where id = %s returning id"
-            cursor.execute(sql, (updated.batch_id, updated.content, updated.associate_id, updated.week_number, updated.note_id))
+            cursor.execute(
+                sql, (updated.batch_id, updated.content, updated.associate_id,
+                      updated.week_number, updated.note_id))
             conn.commit()
             n_id = cursor.fetchone()
             if n_id is not None:

--- a/daos/daos_impl/note_dao_impl.py
+++ b/daos/daos_impl/note_dao_impl.py
@@ -7,7 +7,8 @@ from models.note import Note
 
 class NoteDAOImpl(NoteDao):
 
-    def add_note(self, cursor, note: Note) -> Note:
+    @staticmethod
+    def add_note(cursor, note: Note) -> Note:
         if note.week_number < 0:
             raise ValueError()
         try:
@@ -22,7 +23,8 @@ class NoteDAOImpl(NoteDao):
             if int(e.pgcode) == 23503 or int(e.pgcode) == 42830:
                 raise ResourceNotFound("The foreign keys provided do not exist")
 
-    def get_single_note(self, cursor, note_id: int) -> Note:
+    @staticmethod
+    def get_single_note(cursor, note_id: int) -> Note:
         """Takes in an id for a note record and returns a Note object"""
         sql = "select * from notes where id = %s"
         cursor.execute(sql, [note_id])
@@ -38,7 +40,8 @@ class NoteDAOImpl(NoteDao):
         else:
             raise ResourceNotFound("No note could be found with the given id")
 
-    def get_all_notes(self, cursor) -> list[Note]:
+    @staticmethod
+    def get_all_notes(cursor) -> list[Note]:
         """Returns all the notes"""
         sql = "select * from notes"
         cursor.execute(sql)
@@ -53,7 +56,8 @@ class NoteDAOImpl(NoteDao):
                      week_number=note[4]))
         return notes
 
-    def update_note(self, cursor, updated: Note) -> Note:
+    @staticmethod
+    def update_note(cursor, updated: Note) -> Note:
         """Updates note"""
         if updated.week_number < 0:
             raise ValueError()
@@ -71,7 +75,8 @@ class NoteDAOImpl(NoteDao):
             if int(e.pgcode) == 23503 or int(e.pgcode) == 42830:
                 raise ResourceNotFound("The foreign keys provided do not exist")
 
-    def delete_note(self, cursor, note_id: int) -> bool:
+    @staticmethod
+    def delete_note(cursor, note_id: int) -> bool:
         """Deletes a note and returns True if successful"""
         sql = "delete from notes where id = %s returning id"
         cursor.execute(sql, [note_id])

--- a/daos/daos_impl/trainer_dao_impl.py
+++ b/daos/daos_impl/trainer_dao_impl.py
@@ -4,12 +4,10 @@ from models.batch import Batch
 from daos.trainer_dao import TrainerDAO
 from exceptions.resource_not_found import ResourceNotFound
 from models.trainer import Trainer
-from utils.connection import Connection
-
-conn = Connection.conn
 
 
 class TrainerDAOImpl(TrainerDAO):
+
     @staticmethod
     def get_trainer_by_id(cursor, trainer_id):
         sql = "SELECT * FROM trainers WHERE id=%s"
@@ -91,8 +89,7 @@ class TrainerDAOImpl(TrainerDAO):
         return trainer
 
     @staticmethod
-    def create_trainer_batch(cursor, trainer: Trainer, batch: Batch,
-                             role: str):
+    def create_trainer_batch(cursor, trainer: Trainer, batch: Batch, role: str):
         """Create a new trainer_batch join"""
         # ! For testing use only
         sql = """\
@@ -101,6 +98,5 @@ class TrainerDAOImpl(TrainerDAO):
             values
                 (%s, %s, %s, %s, %s)"""
         cursor.execute(
-            sql,
-            [trainer.id, batch.id, batch.start_date, batch.end_date, role])
+            sql, [trainer.id, batch.id, batch.start_date, batch.end_date, role])
         return True

--- a/sample_conn_cred.txt
+++ b/sample_conn_cred.txt
@@ -1,6 +1,18 @@
+; Remember to change the name of this file to conn_cred.ini after adding
+; your connection details!
+
 [postgresql]
 host=
 database=postgres
 user=
 password=
 port=5432
+options=-c search_path=<main_schema>
+
+[postgresql_test]
+host=
+database=postgres
+user=
+password=
+port=5432
+options=-c search_path=<test_schema>

--- a/services/associate_services.py
+++ b/services/associate_services.py
@@ -3,7 +3,7 @@ from models.associate import Associate
 from daos.daos_impl.associate_dao_impl import AssociateDAOImpl
 from utils.connection import Connection
 
-conn = Connection.conn
+conn = Connection().conn
 
 
 class AssociateServices:

--- a/services/batch_services.py
+++ b/services/batch_services.py
@@ -2,9 +2,11 @@ from daos.daos_impl.batch_dao_impl import BatchDAOImpl
 from models.batch import Batch
 from utils.connection import Connection
 
-conn = Connection.conn
+conn = Connection().conn
+
 
 class BatchServices:
+
     @classmethod
     def create_batch(cls, batch: Batch):
         with conn:

--- a/services/note_service.py
+++ b/services/note_service.py
@@ -5,34 +5,36 @@ from models.note import Note
 
 class NoteService(ABC):
 
-    #Create
+    # Create
     @abstractmethod
     def add_note(self, note: Note) -> Note:
         pass
 
-    #Read
+    # Read
     @abstractmethod
     def get_single_note(self, note_id: int) -> Note:
         pass
+
     @abstractmethod
     def get_all_notes(self) -> list[Note]:
         pass
 
-    #Update
+    # Update
     @abstractmethod
     def update_note(self, note: Note) -> Note:
         pass
 
-    #Delete
+    # Delete
     @abstractmethod
     def delete_note(self, note_id: int) -> bool:
         pass
 
-
-    #Business Logic
+    # Business Logic
     @abstractmethod
     def get_all_notes_for_trainee(self, associate_id: int) -> list[Note]:
         pass
+
     @abstractmethod
-    def get_all_notes_for_trainee_for_week(self, associate_id: int, week_number: int) -> list[Note]:
+    def get_all_notes_for_trainee_for_week(self, associate_id: int,
+                                           week_number: int) -> list[Note]:
         pass

--- a/services/note_service_impl.py
+++ b/services/note_service_impl.py
@@ -3,10 +3,11 @@ from models.note import Note
 from services.note_service import NoteService
 from utils.connection import Connection
 
-conn = Connection.conn
+conn = Connection().conn
 
 
 class NoteServiceImpl(NoteService):
+
     def __init__(self, note_dao: NoteDao):
         self.note_dao = note_dao
 
@@ -45,7 +46,8 @@ class NoteServiceImpl(NoteService):
                         to_return.append(note)
                 return to_return
 
-    def get_all_notes_for_trainee_for_week(self, associate_id: int, week_number: int) -> list[Note]:
+    def get_all_notes_for_trainee_for_week(self, associate_id: int,
+                                           week_number: int) -> list[Note]:
         with conn:
             with conn.cursor() as cursor:
                 all_notes = self.note_dao.get_all_notes(cursor)

--- a/services/trainer_service.py
+++ b/services/trainer_service.py
@@ -1,7 +1,7 @@
 from daos.daos_impl.trainer_dao_impl import TrainerDAOImpl
 from utils.connection import Connection
 
-conn = Connection.conn
+conn = Connection().conn
 
 
 class TrainerService:

--- a/tests/dao_tests/associate_test.py
+++ b/tests/dao_tests/associate_test.py
@@ -1,7 +1,6 @@
 from copy import copy
 from daos.daos_impl.associate_dao_impl import AssociateDAOImpl as a
 from daos.daos_impl.batch_dao_impl import BatchDAOImpl as b
-from datetime import date
 from exceptions.resource_not_found import ResourceNotFound
 from models.associate import Associate
 from models.batch import Batch

--- a/tests/dao_tests/associate_test.py
+++ b/tests/dao_tests/associate_test.py
@@ -8,7 +8,7 @@ from models.batch import Batch
 from pytest import raises
 from utils.connection import Connection
 
-conn = Connection.conn
+conn = Connection().conn
 ASSOCIATE = Associate("Testy", "McTesterson", "test@test.test", "")
 BATCH = Batch("Batchy", "Snek", 1625788800, 1631145600)
 

--- a/tests/dao_tests/batch_dao_test.py
+++ b/tests/dao_tests/batch_dao_test.py
@@ -8,9 +8,8 @@ from utils.connection import Connection
 import psycopg2
 import pytest
 
-conn = Connection.conn
-TEST_BATCH = Batch("TestBatch", "Python Automation", 1625788800,
-                   1631145600)
+conn = Connection().conn
+TEST_BATCH = Batch("TestBatch", "Python Automation", 1625788800, 1631145600)
 TRAINER = Trainer("Trainer", "McTrainerFace", "i@like.trains")
 
 
@@ -22,6 +21,7 @@ def test_create_batch():
             assert test_batch.id != -1
         conn.rollback()
 
+
 def test_invalid_date_format_create_batch():
     with pytest.raises(psycopg2.errors.InvalidDatetimeFormat):
         test_batch: Batch = Batch("TestBatch2", "Baking", "start_date",
@@ -29,6 +29,7 @@ def test_invalid_date_format_create_batch():
         with conn:
             with conn.cursor() as cursor:
                 test_batch = b.create_batch(cursor, test_batch)
+
 
 def test_invalid_date_value_create_batch():
     with pytest.raises(ValueError):

--- a/tests/dao_tests/batch_dao_test.py
+++ b/tests/dao_tests/batch_dao_test.py
@@ -1,5 +1,4 @@
 from copy import copy
-from datetime import datetime
 
 from models.trainer import Trainer
 from daos.daos_impl.batch_dao_impl import BatchDAOImpl as b
@@ -41,11 +40,13 @@ def test_invalid_date_value_create_batch():
             with conn.cursor() as cursor:
                 test_batch = b.create_batch(cursor, test_batch)
 
+
 def test_total_weeks():
-    start = 1626106659
-    end = 1636733874
+    start = 1626113692
+    end = 1631470495
     batch = Batch("New Batch", "Epoch Time", start, end)
     assert batch.total_weeks() == 8
+
 
 def test_get_all_batches_by_year():
     with conn:

--- a/tests/dao_tests/note_dao_test.py
+++ b/tests/dao_tests/note_dao_test.py
@@ -1,78 +1,119 @@
-import unittest
-
-from daos.daos_impl.note_dao_impl import NoteDAOImpl
+from copy import copy
+from daos.daos_impl.associate_dao_impl import AssociateDAOImpl as a
+from daos.daos_impl.batch_dao_impl import BatchDAOImpl as b
+from daos.daos_impl.note_dao_impl import NoteDAOImpl as n
 from exceptions.resource_not_found import ResourceNotFound
+from models.associate import Associate
+from models.batch import Batch
 from models.note import Note
+from pytest import raises
 from utils.connection import Connection
 
 conn = Connection().conn
 
-note_dao = NoteDAOImpl()
+ASSOCIATE = Associate("Testy", "McTesterson", "test@test.test", "")
+BATCH = Batch("TestBatch", "Python Automation", 1625788800, 1631145600)
+TEST_NOTE = Note(0, 1, 1, 1, "Test Note")
 
-test_note = Note(0, 1, 1, 1, "Test Note")
+
+def test_create_note():
+    with conn:
+        with conn.cursor() as cursor:
+            associate = copy(ASSOCIATE)
+            batch = copy(BATCH)
+            associate.id = a.create_associate(cursor, associate).id
+            batch.id = b.create_batch(cursor, batch).id
+            test_note = Note(0, batch.id, associate.id, 1, "Test Note")
+            test_note.note_id = n.add_note(cursor, test_note).note_id
+            assert test_note.note_id != 0
+        conn.rollback()
 
 
-class NoteDAOTest(unittest.TestCase):
+def test_get_single_note():
+    with conn:
+        with conn.cursor() as cursor:
+            associate = copy(ASSOCIATE)
+            batch = copy(BATCH)
+            associate.id = a.create_associate(cursor, associate).id
+            batch.id = b.create_batch(cursor, batch).id
+            test_note = Note(0, batch.id, associate.id, 1, "Test Note")
+            test_note.note_id = n.add_note(cursor, test_note).note_id
+            assert n.get_single_note(cursor, test_note.note_id)
+        conn.rollback()
 
-    def test_create_note(self):
-        with conn:
-            with conn.cursor() as cursor:
-                note_dao.add_note(cursor, test_note)
-                assert test_note.note_id != 0
-            conn.rollback()
 
-    def test_get_single_note(self):
-        with conn:
-            with conn.cursor() as cursor:
-                note_dao.add_note(cursor, test_note)
-                assert note_dao.get_single_note(cursor, test_note.note_id)
-            conn.rollback()
+def test_get_single_note_fail():
+    with conn:
+        with conn.cursor() as cursor:
+            associate = copy(ASSOCIATE)
+            batch = copy(BATCH)
+            associate.id = a.create_associate(cursor, associate).id
+            batch.id = b.create_batch(cursor, batch).id
+            test_note = Note(0, batch.id, associate.id, 1, "Test Note")
+            test_note.note_id = n.add_note(cursor, test_note).note_id
+            with raises(ResourceNotFound):
+                n.get_single_note(cursor, 200)
+        conn.rollback()
 
-    def test_get_single_note_fail(self):
-        with conn:
-            with conn.cursor() as cursor:
-                try:
-                    note_dao.get_single_note(cursor, 200)
-                except ResourceNotFound:
-                    assert True
-            conn.rollback()
 
-    def test_get_all_notes(self):
-        with conn:
-            with conn.cursor() as cursor:
-                assert note_dao.get_all_notes(cursor)
-            conn.rollback()
+def test_get_all_notes():
+    with conn:
+        with conn.cursor() as cursor:
+            associate = copy(ASSOCIATE)
+            batch = copy(BATCH)
+            associate.id = a.create_associate(cursor, associate).id
+            batch.id = b.create_batch(cursor, batch).id
+            test_note = Note(0, batch.id, associate.id, 1, "Test Note")
+            test_note.note_id = n.add_note(cursor, test_note).note_id
+            notes = n.get_all_notes(cursor)
+            assert len(notes) != 0
+        conn.rollback()
 
-    def test_update_note(self):
-        with conn:
-            with conn.cursor() as cursor:
-                test_note.content = 'Updated content'
-                note = note_dao.update_note(cursor, test_note)
-                assert note.content == test_note.content
-            conn.rollback()
 
-    def test_update_note_fail(self):
-        with conn:
-            with conn.cursor() as cursor:
-                try:
-                    test_note.note_id = 200
-                    note_dao.update_note(cursor, test_note)
-                except ResourceNotFound:
-                    assert True
-            conn.rollback()
+def test_update_note():
+    with conn:
+        with conn.cursor() as cursor:
+            associate = copy(ASSOCIATE)
+            batch = copy(BATCH)
+            associate.id = a.create_associate(cursor, associate).id
+            batch.id = b.create_batch(cursor, batch).id
+            test_note = Note(0, batch.id, associate.id, 1, "Test Note")
+            test_note.note_id = n.add_note(cursor, test_note).note_id
+            upd_note = n.get_single_note(cursor, test_note.note_id)
+            upd_note.content = 'Updated content'
+            note = n.update_note(cursor, upd_note)
+            assert note.content == upd_note.content
+        conn.rollback()
 
-    def test_delete_note(self):
-        with conn:
-            with conn.cursor() as cursor:
-                assert note_dao.delete_note(cursor, test_note.note_id)
-            conn.rollback()
 
-    def test_delete_note_fail(self):
-        with conn:
-            with conn.cursor() as cursor:
-                try:
-                    test_note.note_id = 200
-                    note_dao.delete_note(cursor, test_note.note_id)
-                except ResourceNotFound:
-                    assert True
-            conn.rollback()
+def test_update_note_fail():
+    with conn:
+        with conn.cursor() as cursor:
+            with raises(ResourceNotFound):
+                test_note = copy(TEST_NOTE)
+                test_note.note_id = 0
+                n.update_note(cursor, test_note)
+        conn.rollback()
+
+
+def test_delete_note():
+    with conn:
+        with conn.cursor() as cursor:
+            associate = copy(ASSOCIATE)
+            batch = copy(BATCH)
+            associate.id = a.create_associate(cursor, associate).id
+            batch.id = b.create_batch(cursor, batch).id
+            test_note = Note(0, batch.id, associate.id, 1, "Test Note")
+            test_note.note_id = n.add_note(cursor, test_note).note_id
+            assert n.delete_note(cursor, test_note.note_id)
+        conn.rollback()
+
+
+def test_delete_note_fail():
+    with conn:
+        with conn.cursor() as cursor:
+            with raises(ResourceNotFound):
+                test_note = copy(TEST_NOTE)
+                test_note.note_id = 0
+                n.delete_note(cursor, test_note.note_id)
+        conn.rollback()

--- a/tests/dao_tests/note_dao_test.py
+++ b/tests/dao_tests/note_dao_test.py
@@ -5,7 +5,7 @@ from exceptions.resource_not_found import ResourceNotFound
 from models.note import Note
 from utils.connection import Connection
 
-conn = Connection.conn
+conn = Connection().conn
 
 note_dao = NoteDAOImpl()
 
@@ -13,6 +13,7 @@ test_note = Note(0, 1, 1, 1, "Test Note")
 
 
 class NoteDAOTest(unittest.TestCase):
+
     def test_create_note(self):
         with conn:
             with conn.cursor() as cursor:

--- a/tests/dao_tests/trainer_dao_test.py
+++ b/tests/dao_tests/trainer_dao_test.py
@@ -7,9 +7,9 @@ from daos.daos_impl.batch_dao_impl import BatchDAOImpl as b
 from exceptions.resource_not_found import ResourceNotFound
 from utils.connection import Connection
 
-conn = Connection.conn
+conn = Connection().conn
 
-BATCH = Batch("TestBatch", "Python Automation", 1625788800,  1631145600)
+BATCH = Batch("TestBatch", "Python Automation", 1625788800, 1631145600)
 TRAINER = Trainer("Trainer", "McTrainerFace", "i@like.trains")
 
 

--- a/utils/connection.py
+++ b/utils/connection.py
@@ -5,16 +5,15 @@ from psycopg2 import connect
 
 class Connection():
 
-    # def __init__(self, test: bool = False):
-    #     self.test = test
+    def __init__(self, test: bool = False):
+        self.conn = connect(**self.load_conn(test))
 
-    def load_conn():
+    def load_conn(self, test):
         conn_file = "conn_cred.ini"
-        # if self.test:
-        #     section = "postgresql_test"
-        # else:
-        #     section = "postgresql"
-        section = "postgresql"
+        if test:
+            section = "postgresql_test"
+        else:
+            section = "postgresql"
         parser = ConfigParser()
         db = {}
 
@@ -35,8 +34,7 @@ class Connection():
 
         return db
 
-    conn = connect(**load_conn())
-
 
 if __name__ == "__main__":
-    Connection()
+    conn = Connection().conn
+    print(conn)

--- a/utils/connection.py
+++ b/utils/connection.py
@@ -4,8 +4,16 @@ from psycopg2 import connect
 
 
 class Connection():
+
+    # def __init__(self, test: bool = False):
+    #     self.test = test
+
     def load_conn():
         conn_file = "conn_cred.ini"
+        # if self.test:
+        #     section = "postgresql_test"
+        # else:
+        #     section = "postgresql"
         section = "postgresql"
         parser = ConfigParser()
         db = {}


### PR DESCRIPTION
Major changes:
- Connection is now instanced instead of static. Calling Connection(test=True) will send SQL requests the database or schema configured in conn_cred.ini's [postgresql_test] section.
- Explicit conn.commit() calls removed from note_dao to maintain TCL access.
- note_dao_test converted to pytest format and edited to be atomic.
- unneeded Connection objects removed from daos.